### PR TITLE
Switch parent updates to subjects /w debounce

### DIFF
--- a/frontend/src/app/schools/school-map/school-map.component.html
+++ b/frontend/src/app/schools/school-map/school-map.component.html
@@ -1,6 +1,6 @@
 <mat-card class="map-container">
-  <agm-map [zoom]="mapZoom" [disableDefaultUI]="true" [latitude]="mapLat" [longitude]="mapLng" [minZoom]="maxConstraint"
-    [clickableIcons]="false" (boundsChange)="boundsChanged.emit($event)">
+  <agm-map (zoomChange)="zoomChanged.emit($event)" (centerChange)="centerChanged.emit($event)" [zoom]="mapZoom" [disableDefaultUI]="true"
+    [latitude]="mapLat" [longitude]="mapLng" [minZoom]="maxConstraint" [clickableIcons]="false" (boundsChange)="boundsChanged.emit($event)">
     <agm-marker *ngFor="let school of schools" [latitude]="school.location_1.coordinates[1]" [longitude]="school.location_1.coordinates[0]"
       [iconUrl]="'./assets/icons/school.png'">
       <agm-snazzy-info-window class="marker-window" padding="0" maxWidth="800" [closeWhenOthersOpen]="true" [showCloseButton]="false">
@@ -25,4 +25,4 @@
       </agm-snazzy-info-window>
     </agm-marker>
   </agm-map>
-</mat-card> 
+</mat-card>

--- a/frontend/src/app/schools/school-map/school-map.component.ts
+++ b/frontend/src/app/schools/school-map/school-map.component.ts
@@ -15,7 +15,9 @@ export class SchoolMapComponent {
   @Output() boundsChanged = new EventEmitter();
   @Output() focused = new EventEmitter();
   @Output() zoomChanged = new EventEmitter();
+  @Output() centerChanged = new EventEmitter();
   maxConstraint = 12;
 
   constructor() {}
+
 }

--- a/frontend/src/app/schools/schools.component.html
+++ b/frontend/src/app/schools/schools.component.html
@@ -1,20 +1,11 @@
 <section class="schools-container">
   <div class="search-container">
-    <app-schools-search-form
-      (formSubmitted)="searchSchools($event)">
+    <app-schools-search-form (formSubmitted)="searchSchools($event)">
     </app-schools-search-form>
-    <app-school-option
-      (changed)="checkPoliceToggle($event)">
+    <app-school-option (changed)="checkPoliceToggle($event)">
     </app-school-option>
   </div>
-    <app-school-map
-    class="map-container"
-    [schools]="schools"
-    [policeEvents]="policeEvents"
-    [mapZoom]="zoom"
-    [mapLat]="lat"
-    [mapLng]="lng"
-    (boundsChanged)="storeMapBounds($event)"
-    (focused)="focusOnSchool($event)">
+  <app-school-map class="map-container" [schools]="schools" [policeEvents]="policeEvents" [mapZoom]="zoom" [mapLat]="lat" [mapLng]="lng"
+    (boundsChanged)="storeMapBounds($event)" (focused)="focusOnSchool($event)" (zoomChanged)="setZoom($event)" (centerChanged)="setCenter($event)">
   </app-school-map>
 </section>


### PR DESCRIPTION
Zoom update and center update are controlled with debounced subjects. This allows the map to update after a delay, preventing inconsistent updates when the user zooms or changes center.

Also allows the focus on school button to work more than once as originally intended.